### PR TITLE
Add dice command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import BanCommand from "./src/moderation/ban/BanCommand";
 import PurgeCommand from "./src/moderation/purge/PurgeCommand";
 import ButtonRolesCommand from "./src/moderation/roles/ButtonRolesCommand";
 import ButtonRolesInteractionListener from "./src/moderation/roles/ButtonRolesInteractionListener";
+import DiceCommand from "./src/fun/dice/DiceCommand";
 import AnimeCommand from "./src/fun/anime/AnimeCommand";
 import PlayCommand from "./src/music/PlayCommand";
 import PauseCommand from "./src/music/PauseCommand";
@@ -52,6 +53,7 @@ let prefix: string = store.get("prefix");
 const handler: EventHandler = new EventHandler(client, store, prefix);
 
 handler.registerCommand(AnimeCommand);
+handler.registerCommand(DiceCommand);
 
 handler.registerCommand(SuggestionsCommand);
 handler.registerCommand(ServerConfigCommand);

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -1,5 +1,6 @@
 import Command from "../../core/Command";
-import { Message, MessageEmbed } from "discord.js";
+import { Message } from "discord.js";
+import { createBaseEmbed } from "../util/Messages";
 import Store from "../../core/Store";
 import Constants from "../../core/Constants";
 
@@ -15,38 +16,38 @@ class DiceCommand extends Command {
     async execute(msg: Message, args: string[]) {
         if (args.length === 0) {
             var rand = Math.floor(Math.random() * 6) + 1;
-            await msg.channel.send("You rolled a " + rand, Constants.black);
+            await msg.channel.send(createBaseEmbed("You rolled a " + rand, Constants.black));
         } else if (args.length === 1 && args[0] === "help"){
-            await msg.channel.send(`Available commands are:
+            await msg.channel.send(createBaseEmbed(`Available commands are:
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
 \`-dice <stuff>\` - choose randomly from a list of comma separated stuff
 \`-dice <min> <max>\` - choose randomly between numbers in a range
-\`-dice help\` - show this help message`, Constants.black);
+\`-dice help\` - show this help message`, Constants.black));
         } else if (args.length === 1 && !isNaN(parseFloat(args[0]))){
             var rand = Math.floor(Math.random() * parseFloat(args[0])) + 1;
-            await msg.channel.send("You rolled a " + rand, Constants.black);
+            await msg.channel.send(createBaseEmbed("You rolled a " + rand, Constants.black));
         } else if (args.length === 2 && !isNaN(parseFloat(args[0])) && !isNaN(parseFloat(args[1]))){
             var a = parseFloat(args[0]);
             var b = parseFloat(args[1]);
             var min = Math.min(a, b);
             var max = Math.max(a, b);
             var rand = Math.ceil(Math.random() * (max - min + 1) + (min - 1))
-            await msg.channel.send("You rolled a " + rand, Constants.black);
+            await msg.channel.send(createBaseEmbed("You rolled a " + rand, Constants.black));
         } else if (args.length === 1 && args[0].split(",").length > 1){
             var rand = Math.floor(Math.random() * args[0].split(",").length);
             var list = args[0].split(",");
             list.forEach((e, i, a) => {
               a[i] = e.trim()
             })
-            await msg.channel.send("You rolled " + list[rand], Constants.black);
+            await msg.channel.send(createBaseEmbed("You rolled " + list[rand], Constants.black));
         } else {
-            await msg.channel.send(`Command not recognized. Available commands are:
+            await msg.channel.send(createBaseEmbed(`Command not recognized. Available commands are:
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
 \`-dice <stuff>\` - choose randomly from a list of comma separated stuff
 \`-dice <min> <max>\` - choose randomly between numbers in a range
-\`-dice help\` - show this help message`, Constants.black);
+\`-dice help\` - show this help message`, 0x89023e));
         }
     }
 }

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -20,7 +20,7 @@ class DiceCommand extends Command {
             await msg.channel.send(`Available commands are:
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
-\`-dice <stuff>\` - choose randomly from a list of comma seperated stuff
+\`-dice <stuff>\` - choose randomly from a list of comma separated stuff
 \`-dice <min> <max>\` - choose randomly between numbers in a range
 \`-dice help\` - show this help message`, Constants.black);
         } else if (args.length === 1 && !isNaN(parseFloat(args[0]))){
@@ -44,7 +44,7 @@ class DiceCommand extends Command {
             await msg.channel.send(`Command not recognized. Available commands are:
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
-\`-dice <stuff>\` - choose randomly from a list of comma seperated stuff
+\`-dice <stuff>\` - choose randomly from a list of comma separated stuff
 \`-dice <min> <max>\` - choose randomly between numbers in a range
 \`-dice help\` - show this help message`, Constants.black);
         }

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -22,14 +22,14 @@ class DiceCommand extends Command {
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
 \`-dice <stuff>\` - choose randomly from a list of comma separated stuff
-\`-dice <min> <max>\` - choose randomly between numbers in a range
+\`-dice <min>-<max>\` - choose randomly between numbers in a range
 \`-dice help\` - show this help message`, Constants.black));
         } else if (args.length === 1 && !isNaN(parseFloat(args[0]))){
             var rand = Math.floor(Math.random() * parseFloat(args[0])) + 1;
             await msg.channel.send(createBaseEmbed("You rolled a " + rand, Constants.black));
-        } else if (args.length === 2 && !isNaN(parseFloat(args[0])) && !isNaN(parseFloat(args[1]))){
-            var a = parseFloat(args[0]);
-            var b = parseFloat(args[1]);
+        } else if (args.length === 1 && !isNaN(parseFloat(args[0].split("-")[0])) && !isNaN(parseFloat(args[0].split("-")[1]))){
+            var a = parseFloat(args[0].split("-")[0]);
+            var b = parseFloat(args[0].split("-")[1]);
             var min = Math.min(a, b);
             var max = Math.max(a, b);
             var rand = Math.ceil(Math.random() * (max - min + 1) + (min - 1))
@@ -46,7 +46,7 @@ class DiceCommand extends Command {
 \`-dice\` - roll a 6-sided dice
 \`-dice <sides>\` - roll a dice with a specific amount of sides
 \`-dice <stuff>\` - choose randomly from a list of comma separated stuff
-\`-dice <min> <max>\` - choose randomly between numbers in a range
+\`-dice <min>-<max>\` - choose randomly between numbers in a range
 \`-dice help\` - show this help message`, 0x89023e));
         }
     }

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -1,6 +1,6 @@
 import Command from "../../core/Command";
 import { Message } from "discord.js";
-import { createBaseEmbed } from "../util/Messages";
+import { createBaseEmbed } from "../../util/Messages";
 import Store from "../../core/Store";
 import Constants from "../../core/Constants";
 

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -24,7 +24,7 @@ class DiceCommand extends Command {
 \`-dice <stuff>\` - choose randomly from a list of comma separated stuff
 \`-dice <min>-<max>\` - choose randomly between numbers in a range
 \`-dice help\` - show this help message`, Constants.black));
-        } else if (args.length === 1 && !isNaN(parseFloat(args[0]))){
+        } else if (args.length === 1 && !isNaN(parseFloat(args[0])) && parseFloat(args[0]).toString() === args[0]){
             var rand = Math.floor(Math.random() * parseFloat(args[0])) + 1;
             await msg.channel.send(createBaseEmbed("You rolled a " + rand, Constants.black));
         } else if (args.length === 1 && !isNaN(parseFloat(args[0].split("-")[0])) && !isNaN(parseFloat(args[0].split("-")[1]))){

--- a/src/fun/dice/DiceCommand.ts
+++ b/src/fun/dice/DiceCommand.ts
@@ -1,0 +1,54 @@
+import Command from "../../core/Command";
+import { Message, MessageEmbed } from "discord.js";
+import Store from "../../core/Store";
+import Constants from "../../core/Constants";
+
+class DiceCommand extends Command {
+    constructor(store: Store, prefix: string) {
+        super(store, prefix, "dice", 1);
+    }
+
+    checkPermission(msg: Message) {
+        return !msg.author.bot;
+    }
+
+    async execute(msg: Message, args: string[]) {
+        if (args.length === 0) {
+            var rand = Math.floor(Math.random() * 6) + 1;
+            await msg.channel.send("You rolled a " + rand, Constants.black);
+        } else if (args.length === 1 && args[0] === "help"){
+            await msg.channel.send(`Available commands are:
+\`-dice\` - roll a 6-sided dice
+\`-dice <sides>\` - roll a dice with a specific amount of sides
+\`-dice <stuff>\` - choose randomly from a list of comma seperated stuff
+\`-dice <min> <max>\` - choose randomly between numbers in a range
+\`-dice help\` - show this help message`, Constants.black);
+        } else if (args.length === 1 && !isNaN(parseFloat(args[0]))){
+            var rand = Math.floor(Math.random() * parseFloat(args[0])) + 1;
+            await msg.channel.send("You rolled a " + rand, Constants.black);
+        } else if (args.length === 2 && !isNaN(parseFloat(args[0])) && !isNaN(parseFloat(args[1]))){
+            var a = parseFloat(args[0]);
+            var b = parseFloat(args[1]);
+            var min = Math.min(a, b);
+            var max = Math.max(a, b);
+            var rand = Math.ceil(Math.random() * (max - min + 1) + (min - 1))
+            await msg.channel.send("You rolled a " + rand, Constants.black);
+        } else if (args.length === 1 && args[0].split(",").length > 1){
+            var rand = Math.floor(Math.random() * args[0].split(",").length);
+            var list = args[0].split(",");
+            list.forEach((e, i, a) => {
+              a[i] = e.trim()
+            })
+            await msg.channel.send("You rolled " + list[rand], Constants.black);
+        } else {
+            await msg.channel.send(`Command not recognized. Available commands are:
+\`-dice\` - roll a 6-sided dice
+\`-dice <sides>\` - roll a dice with a specific amount of sides
+\`-dice <stuff>\` - choose randomly from a list of comma seperated stuff
+\`-dice <min> <max>\` - choose randomly between numbers in a range
+\`-dice help\` - show this help message`, Constants.black);
+        }
+    }
+}
+
+export default DiceCommand;


### PR DESCRIPTION
This adds a dice command, as suggested by PeanutButterSandwich on the Koi Discord server. It has four different modes:
`-dice` - roll a 6-sided dice
`-dice <sides>` - roll a dice with a specific amount of sides
`-dice <stuff>` - choose randomly from a list of comma separated stuff
`-dice <min> <max>` - choose randomly between numbers in a range
It also has a help message which will show either if an invalid command is entered or if `-dice help` is entered.